### PR TITLE
IETF norms require all-caps for the meaning I believe to be intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Many people have presented various different ways to craft data flow diagrams ov
    4. Data flows are represented by arrows. These are usually two way (bi-directional). A dot can be used to represent the origination side.
    5. A trust boundary is a closed shape, usually a box.
 2. All lines are solid, except those used for trust boundaries, which are dashed or dotted.  (There is no "multi-process" symbol in DFD3.)
-3. It must not* depend on the use of color, but can use color for additional information.
+3. It MUST NOT* depend on the use of color, but can use color for additional information.
 4. All elements should have a label.
 5. You may have a context diagram if the system is complex.  One is not required.
 </ol>
-* Must, must not, should, should not are used per IETF norms.
+* MUST, MUST NOT, SHOULD, SHOULD NOT are used per IETF norms.
 
 
 


### PR DESCRIPTION
Presuming that [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) and [RFC 8174](https://datatracker.ietf.org/doc/html/rfc8174) accurately portray IETF norms. MUST et al MUST be in all caps if you mean them to be interpreted as described in RFC2119, which I believe to be your intent. (I do wonder why you footnoted _four_ RFC 2119 terms, while the document only uses _one_ of these....)